### PR TITLE
Fix JSON configuration and Credential variables

### DIFF
--- a/Src/Public/Invoke-AsBuiltReport.Cisco.UcsManager.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.Cisco.UcsManager.ps1
@@ -22,7 +22,9 @@ function Invoke-AsBuiltReport.Cisco.UcsManager {
         [String]$StylePath
     )
 
-    $InfoLevel = $Global:ReportConfig.InfoLevel
+    # Import JSON Configuration for Section and InfoLevel
+    $InfoLevel = $ReportConfig.InfoLevel
+    $Section = $ReportConfig.Section
     
     #region Configuration Settings
     # If custom style not set, use default style
@@ -32,7 +34,7 @@ function Invoke-AsBuiltReport.Cisco.UcsManager {
 
     foreach ($UCS in $Target) {
         # Connect to Cisco UCS domain using supplied credentials
-        $UCSM = Connect-Ucs -Name $UCS -Credential $Credentials
+        $UCSM = Connect-Ucs -Name $UCS -Credential $Credential
         #endregion Configuration Settings
 
         #region Script Body


### PR DESCRIPTION
Correct issue with missing $Section variable
Rename $Credentials variable to $Credential

## Motivation and Context
Cisco UCS reports were blank due to missing $Section variable.

## How Has This Been Tested?
Tested against lab and production UCS environments

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
